### PR TITLE
Move Voidless Tale styles to central stylesheet

### DIFF
--- a/_includes/voidless-tale.html
+++ b/_includes/voidless-tale.html
@@ -1,0 +1,4 @@
+<section class="voidless-tale">
+  <h2>Voidless Tale</h2>
+  <p>Discover the lore and stories that shape the Voidless universe.</p>
+</section>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,3 +24,19 @@ main {
 a {
   color: #1e90ff;
 }
+
+/* Voidless Tale section */
+.voidless-tale {
+  background-color: #111;
+  padding: 2rem;
+  border-radius: 8px;
+}
+
+.voidless-tale h2 {
+  color: #1e90ff;
+  margin-top: 0;
+}
+
+.voidless-tale p {
+  margin-bottom: 0;
+}

--- a/voidless-tale.md
+++ b/voidless-tale.md
@@ -4,6 +4,4 @@ title: Voidless Tale
 permalink: /voidless-tale/
 ---
 
-# Voidless Tale
-
-Discover the lore and stories that shape the Voidless universe.
+{% include voidless-tale.html %}


### PR DESCRIPTION
## Summary
- add Voidless Tale include without inline styles
- move Voidless Tale section styling into `assets/css/style.css`
- reference include from Voidless Tale page

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6897cbf327908328a79fd16c55fbd2e0