### PR TITLE
Add viewport meta tag for responsive design

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }} - {{ site.title }}</title>
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   </head>


### PR DESCRIPTION
## Summary
- add viewport meta tag to default layout for proper scaling on mobile devices

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6897cbc0e320832890fc88da9d5378f6