### PR TITLE
Add Tailwind configuration and global styles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'astro/config';
-
 export default defineConfig({
-  site: 'https://www.voidlesstale.com',
+  site: 'https://jurislav.github.io', // set to your custom domain once CNAME is live
+  output: 'static',
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root { color-scheme: dark; }
+html, body { background: theme(colors.bg); color: theme(colors.text); }
+
+.panel {
+  @apply rounded-xl2 bg-panel/90 border border-edge/60 shadow-panel backdrop-blur;
+}
+.btn {
+  @apply inline-flex items-center gap-2 rounded-xl2 px-4 py-2 border border-edge/60 bg-surface hover:bg-panel transition;
+}
+.btn-primary {
+  @apply btn border-primary/40 shadow-[0_0_0_1px_rgba(139,92,246,.3)_inset];
+}
+.badge {
+  @apply text-xs tracking-wide px-2 py-0.5 rounded border border-edge/60 bg-surface/60;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/**/*.{astro,html,js,ts,jsx,tsx,md,mdx}"],
+  theme: {
+    extend: {
+      colors: {
+        bg: "#0b0f14",
+        surface: "#12151c",
+        panel: "#161b22",
+        edge: "#2a2f3a",
+        text: "#e5e7eb",
+        mute: "#9ca3af",
+        primary: "#8b5cf6",
+        primarySoft: "#a78bfa"
+      },
+      boxShadow: {
+        panel: "0 1px 0 0 rgba(255,255,255,0.03) inset, 0 8px 30px rgba(0,0,0,0.35)"
+      },
+      borderRadius: { xl2: "1.25rem" }
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Astro for static output and custom site URL
- add Tailwind CSS configuration and theme
- introduce global Tailwind styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa14e9b4d8832887797d0f0d8dd719