### PR TITLE
Add base layout with navigation and footer components

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,10 @@
+<footer class="mt-16 border-t border-edge/60">
+  <div class="mx-auto max-w-6xl px-4 py-10 text-sm text-mute flex flex-wrap items-center gap-4 justify-between">
+    <span>© {new Date().getFullYear()} Voidless Tale</span>
+    <div class="flex gap-3">
+      <a class="badge" href="#">Privacy</a>
+      <a class="badge" href="#">Presskit</a>
+      <a class="badge" href="#">Contact</a>
+    </div>
+  </div>
+</footer>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,18 @@
+---
+const nav = [
+  { href: "/", label: "Home" },
+  { href: "/voidless-tale", label: "Voidless Tale" },
+  { href: "/voidless-smith", label: "Voidless Smith" },
+  { href: "/about", label: "About" },
+];
+---
+<nav class="sticky top-0 z-50 backdrop-blur bg-bg/70 border-b border-edge/60">
+  <div class="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
+    <a href="/" class="font-semibold tracking-wide">VOIDLESS • TALE</a>
+    <ul class="flex items-center gap-2">
+      {nav.map(i => (
+        <li><a class="btn" href={i.href}>{i.label}</a></li>
+      ))}
+    </ul>
+  </div>
+</nav>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,23 @@
+---
+import "../styles/global.css";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+const { title = "Voidless Tale", description = "A 2D pixel-art RPG of sin, power, and redemption." } = Astro.props;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+  </head>
+  <body>
+    <Nav />
+    <main class="mx-auto max-w-6xl px-4 pt-8">
+      <slot />
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable Nav and Footer components with Tailwind classes
- introduce Base layout that imports global styles and wraps pages with Nav and Footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa188cabe48328ab8ff43d600ff135