### PR TITLE
UX: Home hero + store CTA + screenshots + sticky mobile bar + press ribbon

### DIFF
--- a/src/components/PressRibbon.astro
+++ b/src/components/PressRibbon.astro
@@ -1,0 +1,9 @@
+<section class="panel p-4">
+  <div class="kicker mb-1">Highlights</div>
+  <div class="flex flex-wrap items-center gap-2">
+    <span class="badge">Solo Dev</span>
+    <span class="badge">Pixel Art</span>
+    <span class="badge">Mod Support</span>
+    <span class="badge">Action RPG</span>
+  </div>
+</section>

--- a/src/components/StickyStore.astro
+++ b/src/components/StickyStore.astro
@@ -1,0 +1,16 @@
+---
+const items = [
+  { label: 'Steam — Placeholder', href: '#' },
+  { label: 'itch.io — Placeholder', href: '#' },
+];
+---
+<div class="fixed bottom-3 left-0 right-0 z-40 px-4 md:hidden">
+  <div class="panel p-3 backdrop-blur bg-panel/80 border-primary/30">
+    <div class="flex items-center justify-between gap-2">
+      <span class="text-sm text-mute">Wishlist / Follow</span>
+      <div class="flex gap-2">
+        {items.slice(0,2).map(i => <a class="btn btn-primary px-3 py-1.5 text-sm" href={i.href}>{i.label}</a>)}
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -11,8 +11,9 @@ const { title = "Voidless Tale", description = "A 2D pixel-art RPG of sin, power
     <meta property="og:title" content={title} /><meta property="og:description" content={description} />
   </head>
   <body class="vt-gradient vt-noise">
+    <a href="#content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 badge">Skip to content</a>
     <Nav />
-    <main class="mx-auto max-w-6xl px-4 pt-8">
+    <main id="content" class="mx-auto max-w-6xl px-4 pt-8">
       <slot />
     </main>
     <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,9 @@ import Base from "../layouts/Base.astro";
 import Hero from "../components/Hero.astro";
 import PanelCard from "../components/PanelCard.astro";
 import StoreBar from "../components/StoreBar.astro";
+import StickyStore from "../components/StickyStore.astro";
 import MediaRow from "../components/MediaRow.astro";
+import PressRibbon from "../components/PressRibbon.astro";
 import { features } from "../data/voidless";
 ---
 <Base title="Voidless Tale — Home" description="A slick hub for the game & tools.">
@@ -11,10 +13,24 @@ import { features } from "../data/voidless";
         subtitle="Explore mirrored realms, reclaim memories, and forge weapons with Voidless Smith."
         ctas={[{label:'Explore the Game', href:'/voidless-tale/', primary:true},
                {label:'Voidless Smith', href:'/voidless-smith/'}]} />
+
   <div class="mt-6 grid md:grid-cols-3 gap-4">
     {features.slice(0,3).map(f => <PanelCard title={f} />)}
   </div>
-  <div class="mt-6"><StoreBar /></div>
+
+  <div class="mt-6 grid md:grid-cols-3 gap-4">
+    <PanelCard kicker="CTA" title="Wishlist on Steam">
+      <div class="mt-3 flex gap-2 flex-wrap">
+        <a class="btn btn-primary" href="#">Steam — Placeholder</a>
+        <a class="btn" href="#">itch.io — Placeholder</a>
+      </div>
+    </PanelCard>
+    <PressRibbon />
+    <PanelCard kicker="News" title="Devlog">
+      <p class="text-mute">Devlog feed coming soon. For now, follow socials and GitHub.</p>
+    </PanelCard>
+  </div>
+
   <div class="mt-6">
     <MediaRow images={[
       '/assets/screens/s1.jpg',
@@ -22,4 +38,7 @@ import { features } from "../data/voidless";
       '/assets/screens/s3.jpg'
     ]}/>
   </div>
+
+  <div class="mt-6"><StoreBar /></div>
+  <StickyStore />
 </Base>


### PR DESCRIPTION
## Summary
- Enhance Base layout with skip link and gradient canvas.
- Add mobile StickyStore wishlist bar and PressRibbon highlights.
- Revamp Home page with CTA panel, press ribbon, screenshots, and sticky store.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa222eb3348328a6e28add85b44a64