### PR TITLE
Ensure layouts stretch to full viewport

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,10 +10,10 @@ const { title = "Voidless Tale", description = "A 2D pixel-art RPG of sin, power
     <title>{title}</title><meta name="description" content={description} />
     <meta property="og:title" content={title} /><meta property="og:description" content={description} />
   </head>
-  <body class="vt-gradient vt-noise">
+  <body class="vt-gradient vt-noise min-h-screen flex flex-col">
     <a href="#content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 badge">Skip to content</a>
     <Nav />
-    <main id="content" class="mx-auto max-w-6xl px-4 pt-8">
+    <main id="content" class="mx-auto max-w-6xl px-4 pt-8 flex-1 w-full">
       <slot />
     </main>
     <Footer />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,16 +3,22 @@
 @tailwind utilities;
 
 :root { color-scheme: dark; }
+
+/* Ensure page background always fills the viewport */
+html, body { min-height: 100%; }
+
+/* Site base colors */
 html, body { background: theme(colors.bg); color: theme(colors.text); }
 * { -webkit-tap-highlight-color: transparent; }
 
+/* Panels & UI tokens */
 .panel { @apply rounded-xl2 bg-panel/90 border border-edge/60 shadow-panel backdrop-blur; }
 .btn { @apply inline-flex items-center gap-2 rounded-xl2 px-4 py-2 border border-edge/60 bg-surface hover:bg-panel transition; }
 .btn-primary { @apply btn border-primary/40 shadow-[0_0_0_1px_rgba(139,92,246,.35)_inset]; }
 .badge { @apply text-xs tracking-wide px-2 py-0.5 rounded border border-edge/60 bg-surface/60; }
 .kicker { @apply text-xs uppercase tracking-widest text-primary; }
 
-/* Gradient canvas background */
+/* Gradient canvas */
 .vt-gradient {
   background:
     radial-gradient(600px 220px at 15% 10%, rgba(139,92,246,.25), transparent 60%),
@@ -24,4 +30,10 @@ html, body { background: theme(colors.bg); color: theme(colors.text); }
 .vt-noise:before {
   content:""; position:absolute; inset:0; pointer-events:none; opacity:.07;
   background-image: var(--noise, url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' opacity='.7' viewBox='0 0 100 100'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='4'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='.5'/></svg>"));
+}
+
+/* iOS/Safari viewport height quirk safeguard */
+@supports (-webkit-touch-callout: none) {
+  html { height: -webkit-fill-available; }
+  body { min-height: -webkit-fill-available; }
 }


### PR DESCRIPTION
## Summary
- make Base layout a flex column and let main expand so pages fill the viewport
- keep background covering short pages with min-height rules and Safari viewport workaround

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa24fe454483289d7221c3b64b2a9a