### PR TITLE
docs(wiki): seed GDD-driven wiki pages

### DIFF
--- a/wiki/Domains-and-Bosses.md
+++ b/wiki/Domains-and-Bosses.md
@@ -1,0 +1,27 @@
+# Domains & Bosses
+
+Eight domains in each realm (Heaven/Hell), aligned to **S.A.L.I.G.I.A.**:
+
+| # | Sin (Latin) | Heaven (Theme) | Hell (Theme) |
+|:-:|---|---|---|
+| 1 | **Superbia** (Pride) | Radiant Spires & Mirror Halls | Shattered Thrones & Jagged Abyss |
+| 2 | **Avaritia** (Greed) | Vaulted Golden Libraries | Cursed Treasure Troves |
+| 3 | **Luxuria** (Lust) | Perfumed Gardens of Temptation | Flesh-Tangled Catacombs |
+| 4 | **Invidia** (Envy) | Gilded Parade Galleries | Faceless Shadow Corridors |
+| 5 | **Gula** (Gluttony) | Ever-Flowing Manna Fountains | Rotting Feast Halls |
+| 6 | **Ira** (Wrath) | Courtyards of Righteous Flame | Burning Wastelands of Rage |
+| 7 | **Acedia** (Sloth) | Dreamed Cathedrals of Slumber | Decaying Graveyard Stillness |
+| 8 | **SALIGIA** (Final) | **Solagia**, Crown of False Ascension | **Malagia**, Throne of the Abyss Within |
+
+## Boss Lineup (Heaven vs Hell)
+- **Superbia:** Seraphiel · Vantagon  
+- **Avaritia:** Aurum · Gorevault  
+- **Luxuria:** Celestara · Vermissa  
+- **Invidia:** Luminel · Drosselgheist  
+- **Gula:** Feastriel · Bilebloom  
+- **Ira:** Judicar · Rendros  
+- **Acedia:** Soporiel · Nullora  
+- **SALIGIA:** Solagia · Malagia
+
+### Sinful Duality (Endgame)
+Combine rare drops from **both** final SALIGIA versions to craft a **Teleport Stone** that unlocks **Sinful Duality**. Requires level/stat gates and a key crafted from SALIGIA drops.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,16 @@
+# FAQ
+
+### Is there a demo?
+Planned. Watch the site/wiki for updates.
+
+### Steam / itch.io links?
+Buttons are placeholders until pages are live.
+
+### Will there be mod support?
+Yes — the **Voidless Smith** tool and a mod-ready pipeline are core goals.
+
+### Can I reuse names (SALIGIA, domain/boss names)?
+No. Narrative names, characters, and branding are proprietary.
+
+### License?
+Website code: MIT. Creative content & tool branding: **All Rights Reserved**. See **Licensing**.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,21 @@
+# Voidless Tale — Wiki
+
+_A 2D pixel-art action RPG of sin, power, and redemption._  
+Explore mirrored realms of **Heaven** and **Hell**, unlock **memories**, and choose to **loot** items or **absorb** enemy skills to shape your build.
+
+> **Tagline:** **Loot or absorb. Rise or fall.**
+
+## Quick Links
+- **Start:** [Story](Story) • [Domains & Bosses](Domains-and-Bosses) • [Progression & Systems](Progression-and-Systems)  
+- **Create:** [Modding & Voidless Smith](Modding-and-Voidless-Smith)  
+- **Project:** [Roadmap](Roadmap) • [Presskit](Presskit) • [FAQ](FAQ) • [Licensing](Licensing)
+
+## Highlights
+- Dual realms (**Heaven/Hell**) with **8 domains each** (S.A.L.I.G.I.A.).
+- **Loot or Absorb**: take gear or steal skills from enemies/bosses.
+- Level **1–1000** (+3 stat points/level); at **1000** become a **Demigod** (you float).
+- **Repeatable** sin boss fights via crafted keys and memory-gated doors.
+- Everything has value: items feed crafting, keys, or builds.
+- **Modding-first** with the **Voidless Smith** companion tool.
+
+_This wiki summarizes the public GDD. Narrative names, characters, and branding are proprietary (see Licensing)._ 

--- a/wiki/Licensing.md
+++ b/wiki/Licensing.md
@@ -1,0 +1,10 @@
+# Licensing
+
+**Split licensing model:**
+
+- **Website code:** MIT (see repository `LICENSE` for code-specific terms).  
+- **Narrative/creative assets:** **All Rights Reserved** — story, characters, names, lore, domains, boss names; visuals/audio/branding (logos, key art, screenshots, sprites, videos, audio); and any narrative datasets.  
+- **Tools (Voidless Smith):** **All Rights Reserved** — name, brand, binaries/source unless a separate license is explicitly provided.  
+- **Trademarks:** "Voidless Tale", "Voidless Smith", and associated logos/wordmarks are trademarks of **Juris**.
+
+For press & creators: brief excerpts and screenshots may be used for editorial coverage with attribution and a link to **https://www.voidlesstale.com**.

--- a/wiki/Modding-and-Voidless-Smith.md
+++ b/wiki/Modding-and-Voidless-Smith.md
@@ -1,0 +1,21 @@
+# Modding & Voidless Smith
+
+**Voidless Smith** is a standalone tool for weapon parts, palettes, and exports.
+
+## Parts Folders
+- `parts/blade`
+- `parts/hilt`
+- `parts/pomel` _(intentional spelling)_
+
+## Exports
+- **PNG** + **JSON** (UTF-8)
+- Filenames slugged with **underscores**
+- `AttackSpeed` stored as **decimal (2dp)**
+- Stats/names sourced from a **RandomData** pool
+
+## Roadmap
+- In-editor preview/sandbox  
+- One-click export to game mods  
+- `.voidmod` packaging / Workshop
+
+> Tool brand, name, and binaries are proprietary. See **Licensing**.

--- a/wiki/Presskit.md
+++ b/wiki/Presskit.md
@@ -1,0 +1,15 @@
+# Presskit
+
+## Factsheet
+- **Title:** Voidless Tale  
+- **Genre:** 2D Action RPG (side-scrolling)  
+- **Developer:** Juris (solo)  
+- **Elevator:** Loot or absorb. Rise or fall.
+
+## Boilerplate
+Voidless Tale is a 2D pixel-art action RPG exploring sin, duality, and consequence across mirrored realms of Heaven and Hell. Discover memories, craft keys, and face the avatars of S.A.L.I.G.I.A.
+
+## Asset Usage
+- Logos, key art, screenshots, and character names are **proprietary**.  
+- Press may use small excerpts & screenshots for editorial coverage with attribution and a link to **https://www.voidlesstale.com**.  
+- See **Licensing** for details.

--- a/wiki/Progression-and-Systems.md
+++ b/wiki/Progression-and-Systems.md
@@ -1,0 +1,18 @@
+# Progression & Systems
+
+## Leveling & Stats
+- Levels **1 → 1000**
+- **+3 stat points** per level
+- At **1000**: become a **Demigod** (float, endgame tier)
+
+## Rarities
+Common · Uncommon · Rare · Epic · Legendary · **Relic** · **Demigod** (endgame)
+
+## Inventory Tabs
+**Equipment** (paperdoll) · **Materials** (crafting) · **Memories** (story) · **Keys** (boss gates)
+
+## Systems Highlights
+- **Loot or Absorb** defeated enemies/bosses for items or skills  
+- **Skill Absorption** uses **Veinshards** & **Skill Essences**  
+- **Key Crafting** unlocks sin gates and enables repeatable bosses  
+- **Movement/Combat**: side-scrolling, platformer-style action

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,0 +1,8 @@
+# Roadmap (Selected)
+
+- Veinshard ore mining; **Veinshards + Skill Essences** crafting loop  
+- Teleporter plate system for platform traversal  
+- Modular character rig; paper-doll gear swapping & dyeable palettes  
+- Inventory & Stats UI; XP/Leveling; dummy enemy & combat loop  
+- Crafting bench; key crafting flow for sin gates  
+- Devlog & presskit pages on the site

--- a/wiki/Story.md
+++ b/wiki/Story.md
@@ -1,0 +1,11 @@
+# Story & Themes
+
+You awaken **dead**, in a limbo forest beneath a colossal tree. Across the world, scattered **scraps of paper** reveal fragments of your life. Each memory exposes a **sin** you committed, aligning with the S.A.L.I.G.I.A. cycle.
+
+## Themes
+- **Identity & Accountability** — memories confront your past actions.  
+- **Duality** — every domain has a Heaven/Hell reflection.  
+- **Power vs. Consequence** — absorbing power changes you.
+
+## Endgame Twist
+The final boss **SALIGIA** looks like you — a manifestation of yourself. At the end you choose to **rule Heaven**, **rule Hell**, or **escape** back to life (at a cost).

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,2 @@
+**Voidless Tale** — © 2025 Juris. Website code MIT; narrative/characters/brands/tools are proprietary.  
+See: **[Licensing](Licensing)** • **https://www.voidlesstale.com**

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,12 @@
+- **[Home](Home)**
+- **Game**
+  - [Story](Story)
+  - [Domains & Bosses](Domains-and-Bosses)
+  - [Progression & Systems](Progression-and-Systems)
+- **Modding**
+  - [Modding & Voidless Smith](Modding-and-Voidless-Smith)
+- **Project**
+  - [Roadmap](Roadmap)
+  - [Presskit](Presskit)
+  - [FAQ](FAQ)
+  - [Licensing](Licensing)


### PR DESCRIPTION
## Summary
- add sidebar and footer for wiki navigation
- add Home, Story, Domains & Bosses, Progression & Systems pages
- document modding, roadmap, presskit, FAQ, and licensing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2ae023d083288f5144b1366723fd