### PR TITLE
docs: move wiki to dedicated repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ _A 2D pixel-art action RPG of sin, power, and redemption — traverse mirrored r
 
 **Website:** https://www.voidlesstale.com  
 **Wishlist / Follow:** **Steam (placeholder)** · **itch.io (placeholder)**
+**Wiki:** https://github.com/Jurislav/voidlesstale.github.io/wiki
 
 ---
 


### PR DESCRIPTION
## Summary
- remove in-repo wiki folder and link to external wiki
- seed GitHub Wiki with GDD-driven pages: Home, Story, Domains & Bosses, Progression & Systems, Modding, Roadmap, Presskit, FAQ, Licensing

## Testing
- `npm test`
- `npm test` (wiki repository, fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aa2ae023d083288f5144b1366723fd