### PR TITLE
fix(mobile): clamp overflow and add fixed viewport backdrop

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -6,11 +6,18 @@ const { title = "Voidless Tale", description = "A 2D pixel-art RPG of sin, power
 ---
 <html lang="en">
   <head>
-    <meta charset="utf-8" /><meta name="viewport" content="width=device-width" />
-    <title>{title}</title><meta name="description" content={description} />
-    <meta property="og:title" content={title} /><meta property="og:description" content={description} />
+    <meta charset="utf-8" />
+    <!-- Important for iOS safe areas & correct viewport sizing -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
   </head>
-  <body class="vt-gradient vt-noise min-h-screen flex flex-col">
+  <body class="min-h-screen flex flex-col overflow-x-clip">
+    <!-- Fixed full-viewport background (prevents right-edge BG gap on mobile) -->
+    <div class="vt-backdrop vt-gradient vt-noise" aria-hidden="true"></div>
+
     <a href="#content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 badge">Skip to content</a>
     <Nav />
     <main id="content" class="mx-auto max-w-6xl px-4 pt-8 flex-1 w-full">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,12 +4,46 @@
 
 :root { color-scheme: dark; }
 
-/* Ensure page background always fills the viewport */
-html, body { min-height: 100%; }
+/* Prevent page-level horizontal scroll causing BG gaps on mobile */
+html, body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden; /* fallback */
+}
 
-/* Site base colors */
+/* Use clip when supported to avoid creating scrollbars while still cutting overflow */
+@supports (overflow: clip) {
+  html, body { overflow-x: clip; }
+}
+
+/* Base colors */
 html, body { background: theme(colors.bg); color: theme(colors.text); }
-* { -webkit-tap-highlight-color: transparent; }
+* { -webkit-tap-highlight-color: transparent; box-sizing: border-box; }
+
+/* Fixed viewport backdrop (sits behind everything) */
+.vt-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  /* Fallback to classic viewport units */
+  width: 100vw;
+  height: 100vh;
+}
+
+/* Prefer modern dynamic viewport units to avoid toolbar jumps/gaps */
+@supports (width: 100dvw) {
+  .vt-backdrop {
+    width: 100dvw;
+    height: 100dvh;
+  }
+}
+
+/* iOS Safari legacy fallback */
+@supports (-webkit-touch-callout: none) {
+  .vt-backdrop {
+    height: -webkit-fill-available;
+  }
+}
 
 /* Panels & UI tokens */
 .panel { @apply rounded-xl2 bg-panel/90 border border-edge/60 shadow-panel backdrop-blur; }
@@ -25,15 +59,16 @@ html, body { background: theme(colors.bg); color: theme(colors.text); }
     radial-gradient(440px 200px at 85% 15%, rgba(167,139,250,.20), transparent 60%),
     radial-gradient(520px 260px at 50% 120%, rgba(124,58,237,.18), transparent 65%),
     linear-gradient(180deg, rgba(16,20,26,.8), rgba(11,15,20,.95));
+  background-repeat: no-repeat;
+  background-color: theme(colors.bg); /* solid fallback */
 }
+
+/* Film grain */
 .vt-noise { position: relative; }
 .vt-noise:before {
   content:""; position:absolute; inset:0; pointer-events:none; opacity:.07;
   background-image: var(--noise, url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' opacity='.7' viewBox='0 0 100 100'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='4'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='.5'/></svg>"));
 }
 
-/* iOS/Safari viewport height quirk safeguard */
-@supports (-webkit-touch-callout: none) {
-  html { height: -webkit-fill-available; }
-  body { min-height: -webkit-fill-available; }
-}
+/* Media safety: ensure inline media never forces page overflow */
+img, video, canvas { max-width: 100%; height: auto; }


### PR DESCRIPTION
## Summary
- add safer viewport meta and fixed full-viewport background
- clamp horizontal overflow and size backdrop using modern viewport units

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa35b532cc8328855fb1118cddf160