### PR TITLE
feat: add heaven theme switch and boss lineup

### DIFF
--- a/src/components/BossLineup.astro
+++ b/src/components/BossLineup.astro
@@ -1,11 +1,59 @@
 ---
-const HELL = ["Superbia","Avaritia","Luxuria","Invidia","Gula","Ira","Acedia","SALIGIA"];
-const HEAVEN = ["Superbia (Heaven)","Avaritia (Heaven)","Luxuria (Heaven)","Invidia (Heaven)","Gula (Heaven)","Ira (Heaven)","Acedia (Heaven)","SALIGIA (Heaven)"];
+const HELL = [
+  {name:"Superbia (Pride)", blurb:"Punishes overbuffing. Reflect windows force patience.", loot:"Crit & mirror shards", absorb:"Counter-guard / reflect tap"},
+  {name:"Avaritia (Greed)", blurb:"Hoarder boss. Extra drops with weight curses.", loot:"Gold hoards, extra rolls", absorb:"Greed Mark (bonus on last-hit)"},
+  {name:"Luxuria (Lust)", blurb:"Charm debuffs; pet control checks.", loot:"Charm-ward trinkets", absorb:"Allure (brief confuse)"},
+  {name:"Invidia (Envy)", blurb:"Mirror match that copies stats.", loot:"Clone-slayer relics", absorb:"Stat Echo (copy buff)"},
+  {name:"Gula (Gluttony)", blurb:"Eats projectiles; AoE bile zones.", loot:"Acid/poison kits", absorb:"Devour (ammo/bolt convert)"},
+  {name:"Ira (Wrath)", blurb:"Rage meter spikes at 50% HP.", loot:"Berserk mitigators", absorb:"Rage Vent (burst on hit taken)"},
+  {name:"Acedia (Sloth)", blurb:"Time-slow fields with heavy windows.", loot:"Slow resist charms", absorb:"Dilation (brief time skew)"},
+  {name:"SALIGIA (Hell)", blurb:"Two-phase devourer; loot vs absorb ultimatum.", loot:"Relic fusions", absorb:"Sin Engine (limit break)"}
+];
+const HEAVEN = [
+  {name:"Superbia (Heaven)", blurb:"Trials of humility; reward clean play.", loot:"Boons on no-hit", absorb:"Aegis Thread (parry widen)"},
+  {name:"Avaritia (Heaven)", blurb:"Tithe mechanic—share to gain.", loot:"Shared-drop buffs", absorb:"Tithe Sigil (party gain)"},
+  {name:"Luxuria (Heaven)", blurb:"Purity checks vs charm.", loot:"Sanctified wards", absorb:"Clarity Pulse (cleanse)"},
+  {name:"Invidia (Heaven)", blurb:"Copies your *last* build only.", loot:"Mirrorbreaker tools", absorb:"Virtue Copy (one skill)"},
+  {name:"Gula (Heaven)", blurb:"Feast/Fast rhythm; manage stacks.", loot:"Feast buffs on cadence", absorb:"Manna (sustain tap)"},
+  {name:"Ira (Heaven)", blurb:"Wrath transformed to resolve.", loot:"Guarded strike sets", absorb:"Temper (stabilize recoil)"},
+  {name:"Acedia (Heaven)", blurb:"Serenity fields; punish greed.", loot:"Patience procs", absorb:"Stillness (cooldown cut)"},
+  {name:"SALIGIA (Heaven)", blurb:"Dual-judgment; choose mercy or truth.", loot:"Relic ascensions", absorb:"Judicium (stance swap)"}
+];
 ---
+
 <section class="container mx-auto px-4 py-16">
   <h2 class="text-3xl font-bold mb-6">Boss Lineup</h2>
-  <ul class="grid gap-4 md:grid-cols-4 list-none">
-    {HELL.map(n => <li class="card p-4 hell-only"><h3 class="font-semibold">{n}</h3></li>)}
-    {HEAVEN.map(n => <li class="card p-4 heaven-only"><h3 class="font-semibold">{n}</h3></li>)}
+
+  <!-- Hell cards -->
+  <ul class="grid gap-4 md:grid-cols-4 hell-only">
+    {HELL.map((b) => (
+      <li class="card p-4">
+        <h3 class="text-lg font-semibold">{b.name}</h3>
+        <p class="mt-1 text-sm opacity-90">{b.blurb}</p>
+        <ul class="mt-3 text-sm opacity-90">
+          <li><strong>Loot:</strong> {b.loot}</li>
+          <li><strong>Absorb:</strong> {b.absorb}</li>
+        </ul>
+      </li>
+    ))}
+  </ul>
+
+  <!-- Heaven cards -->
+  <ul class="grid gap-4 md:grid-cols-4 heaven-only">
+    {HEAVEN.map((b) => (
+      <li class="card p-4">
+        <h3 class="text-lg font-semibold">{b.name}</h3>
+        <p class="mt-1 text-sm">{b.blurb}</p>
+        <ul class="mt-3 text-sm">
+          <li><strong>Loot:</strong> {b.loot}</li>
+          <li><strong>Absorb:</strong> {b.absorb}</li>
+        </ul>
+      </li>
+    ))}
   </ul>
 </section>
+
+<style>
+:root[data-theme="hell"]   .heaven-only{ display:none !important; }
+:root[data-theme="heaven"] .hell-only  { display:none !important; }
+</style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,9 +2,9 @@
 import "../styles/globals.css";
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
-const { title = "Voidless Tale", description = "A side-scrolling pixel RPG where every enemy is a choice.", theme = "hell" } = Astro.props;
+const { title = "Voidless Tale", description = "A side-scrolling pixel RPG where every enemy is a choice." } = Astro.props;
 ---
-<html lang="en" data-theme={theme}>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
@@ -15,19 +15,35 @@ const { title = "Voidless Tale", description = "A side-scrolling pixel RPG where
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;700&display=swap" />
+    <script is:inline>
+      (function () {
+        const root = document.documentElement;
+        const saved = localStorage.getItem('vt-theme');
+        root.dataset.theme = (saved === 'heaven' || saved === 'hell') ? saved : 'hell';
+      })();
+    </script>
   </head>
-  <body class="min-h-screen flex flex-col overflow-x-clip">
+  <body>
     <div class="vt-backdrop" aria-hidden="true"></div>
     <a href="#content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2">Skip to content</a>
     <Nav className="safenav" />
-    <button data-action="toggle-theme" class="btn fixed z-50" style="top:150px; right:50px;">Switch Theme</button>
     <main id="content" class="mx-auto max-w-6xl px-4 pt-4 sm:pt-6 md:pt-8 flex-1 w-full flow-root">
       <slot />
     </main>
     <Footer />
+    <!-- Fixed theme toggle; must exist on all pages -->
+    <button id="vt-theme-toggle" class="btn-secondary fixed z-50" style="top:150px; right:50px;">
+      Switch Theme
+    </button>
     <script type="module">
-      import { initThemeSwitch } from "../components/ThemeSwitch.ts";
-      initThemeSwitch();
+      const root = document.documentElement;
+      const btn  = document.getElementById('vt-theme-toggle');
+      btn?.addEventListener('click', () => {
+        const next = (root.dataset.theme === 'hell') ? 'heaven' : 'hell';
+        root.dataset.theme = next;
+        localStorage.setItem('vt-theme', next);
+        document.dispatchEvent(new CustomEvent('vt-theme-changed', { detail: next }));
+      });
     </script>
   </body>
 </html>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,38 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
-html[data-theme='hell'], html:not([data-theme]) {
-  --bg: #0b0b0f;
-  --bg-grad-1: #101016;
-  --bg-grad-2: #1a0f14;
-  --accent: #d72638;
-  --accent-2: #ff6b6b;
-  --panel: #17141b;
-  --panel-border: #3a2630;
-  --ink: #e8e8f0;
-  --muted: #b0b0c0;
-  --noise-opacity: .07;
+:root[data-theme="hell"]{
+  --bg:#0b0b0f; --bg-grad-1:#101016; --bg-grad-2:#1a0f14;
+  --accent:#d72638; --accent-2:#ff6b6b;
+  --panel:#17141b; --panel-border:#3a2630;
+  --ink:#e8e8f0; --ink-strong:#ffffff; --muted:#b0b0c0;
+  --noise-opacity:.07;
   --bg-1: var(--bg);
   --bg-2: var(--panel);
   --shadow: rgba(0,0,0,.35);
 }
-:root[data-theme='heaven']{
-  --bg: #1a140b;
-  --bg-grad-1: #0f0b06;
-  --bg-grad-2: #2a1e0c;
-  --accent: #CDA434;
-  --accent-2: #EADBA2;
-  --panel: #F1E6BE;
-  --panel-border: #8B6B23;
-  --ink: #FFF5E1;
-  --muted: #E9D9B9;
-  --noise-opacity: .07;
+:root[data-theme="heaven"]{
+  --bg:#1a140b; --bg-grad-1:#0f0b06; --bg-grad-2:#2a1e0c;
+  --accent:#CDA434; --accent-2:#EADBA2;
+  --panel:#F1E6BE; --panel-border:#8B6B23;
+  --ink:#FFF5E1; --ink-strong:#ffffff; --muted:#E9D9B9;
+  --noise-opacity:.07;
   --bg-1: var(--bg);
   --bg-2: var(--panel);
   --shadow: rgba(0,0,0,.35);
 }
 
-html { color-scheme: dark; background: var(--bg-1); }
+html { color-scheme: dark; background: var(--bg); }
 body { color: var(--ink); font-family: theme('fontFamily.body'); }
 
 /* Backdrop is fixed & empty – visuals live on ::before/::after */
@@ -64,14 +54,6 @@ body { color: var(--ink); font-family: theme('fontFamily.body'); }
   opacity: var(--noise-opacity, .07);
 }
 
-/* Prevent accidental markers or debug squares in hero/lead text */
-.hero p, .lead { list-style:none; }
-.hero p::before, .hero p::after, .lead::before, .lead::after { content:none !important; }
-
-/* Nuke any legacy debug square classes just in case */
-.debug, .vt-cube, .floating-cube, [data-debug]{ display:none !important; }
-.vt-backdrop > *{ display:none !important; }
-
 [data-reveal] {
   opacity: .01;
   transform: translateY(12px);
@@ -84,22 +66,24 @@ body { color: var(--ink); font-family: theme('fontFamily.body'); }
   border-color: var(--accent);
 }
 .btn:hover { background-color: color-mix(in srgb, var(--accent) 20%, transparent); }
-.btn-primary { @apply bg-accent text-bg1; }
+.btn-primary{
+  background:linear-gradient(180deg,var(--accent-2),var(--accent));
+  color:#1a1212; border:1px solid var(--panel-border);
+}
+.btn-secondary{
+  background:transparent; color:var(--ink);
+  border:1px solid var(--accent);
+}
 
 /* Heaven theme – warm gold on deep umber, less glare */
 .card{
-  background: var(--panel);
+  background:var(--panel);
   border:1px solid var(--panel-border);
+  color:var(--ink-strong);
   box-shadow:0 10px 30px -10px rgba(0,0,0,.35);
 }
-[data-theme="heaven"] .card{ color:#2a220f; }
-[data-theme="heaven"] .card h3{ color:#3b2f10; }
-[data-theme="heaven"] .btn-primary{
-  background: linear-gradient(180deg, var(--accent-2), var(--accent));
-  color: #241b0a;
-  border: 1px solid var(--panel-border);
-}
-[data-theme="heaven"] .btn-primary:hover{ filter: brightness(0.95); }
+:root[data-theme="heaven"] .card{ color:#2a220f; }
+:root[data-theme="heaven"] .card h3{ color:#3b2f10; }
 
 :root[data-theme="hell"]   .heaven-only{ display:none !important; }
 :root[data-theme="heaven"] .hell-only  { display:none !important; }
@@ -114,4 +98,17 @@ body { color: var(--ink); font-family: theme('fontFamily.body'); }
   text-shadow: 0 1px 0 #ffffffaa;
 }
 [data-theme="heaven"] .theme-chip.is-active{ outline: 3px solid var(--accent); }
+
+/* Remove stray pseudo-element squares near hero text */
+.hero :where(p,h1,h2,h3,li,a)::before,
+.hero :where(p,h1,h2,h3,li,a)::after,
+.lead::before, .lead::after{ content:none !important; display:none !important; }
+
+/* Hero lists must not show markers */
+.hero ul, .hero ol{ list-style:none; padding-left:0; }
+
+/* If any debug elems slipped in, hide them */
+.debug, .vt-cube, .floating-cube, [data-debug]{ display:none !important; }
+/* Backdrop must be empty: if anything got appended, hide it */
+.vt-backdrop > *{ display:none !important; }
 


### PR DESCRIPTION
## Summary
- restore global backdrop and theme tokens with new Heaven palette
- fix theme switch to toggle `<html data-theme>` and persist choice
- add detailed Hell/Heaven boss lineup cards
- remove stray hero pseudo-elements and debug cubes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab05b2dd1083289d10e051ef2cd844