### PR TITLE
Remove placeholder image from gallery lightbox

### DIFF
--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -16,11 +16,12 @@ const images = [
     ))}
   </div>
   <dialog id="lightbox" class="fixed inset-0 bg-black/80 backdrop-blur flex items-center justify-center p-4">
-    <img src="" alt="" class="max-h-full rounded" />
   </dialog>
   <script type="module">
     const dlg = document.getElementById('lightbox');
-    const img = dlg.querySelector('img');
+    const img = document.createElement('img');
+    img.className = 'max-h-full rounded';
+    dlg.appendChild(img);
     document.querySelectorAll('#gallery button').forEach(btn => {
       btn.addEventListener('click', () => {
         img.src = btn.dataset.image;


### PR DESCRIPTION
## Summary
- remove unused empty image tag from gallery lightbox
- dynamically create image element in script when opening the lightbox

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab13fbf5ec8328a27819b51c9e4429