### PR TITLE
fix: ensure devlog content above backdrop

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,5 +1,5 @@
 ---
-const { className = "" } = Astro.props;
+const { class: className = "" } = Astro.props;
 ---
 <nav class={`fixed top-0 inset-x-0 z-50 backdrop-blur bg-bg1/60 border-b border-accent/20 ${className}`}>
   <div class="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -27,13 +27,13 @@ const {
     <a href="#content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2">Skip to content</a>
     <Nav class="safenav" />
 
-    <!-- IMPORTANT: add vt-content class and use id="content" to match skip link -->
     <main id="content" class="vt-content mx-auto max-w-6xl px-4 pt-4 sm:pt-6 md:pt-8 flex-1 w-full flow-root">
       <slot />
     </main>
 
     <Footer />
 
+    <!-- Theme init + global toggle (unchanged) -->
     <script is:inline>
       (function () {
         const root = document.documentElement;

--- a/src/pages/devlog.astro
+++ b/src/pages/devlog.astro
@@ -1,40 +1,34 @@
 ---
-// src/pages/devlog.astro
 import Base from "../layouts/Base.astro";
 import posts from "../data/devlog.json";
 
 const sorted = [...posts].sort((a, b) => new Date(b.date) - new Date(a.date));
-const fmt = (iso) =>
-  new Date(iso).toLocaleDateString("en-GB", {
-    year: "numeric",
-    month: "short",
-    day: "2-digit",
-  });
+const fmt = (iso) => new Date(iso).toLocaleDateString("en-GB", {
+  year: "numeric", month: "short", day: "2-digit"
+});
 ---
 
-<Base title="Devlog" description="Latest updates and progress logs for Voidless Tale.">
-  {/* Force content above backdrop even if blend is on */}
-  <div style="position:relative; z-index:10; isolation:isolate;">
-    <section class="container mx-auto px-4 py-16">
-      <h1 class="font-heading text-3xl md:text-4xl mb-6" data-reveal>Devlog</h1>
-      <p class="opacity-90 mb-8 max-w-2xl" data-reveal>
-        Changelogs, experiments, and behind-the-scenes notes.
-      </p>
+<Base title="Devlog" description="Latest updates and progress logs for Voidless Tale." pageClass="page-devlog">
+  <section class="container mx-auto px-4 py-16">
+    <h1 class="font-heading text-3xl md:text-4xl mb-6" data-reveal>Devlog</h1>
+    <p class="opacity-90 mb-8 max-w-2xl" data-reveal>
+      Changelogs, experiments, and behind-the-scenes notes.
+    </p>
 
-      <ul class="grid gap-6 md:grid-cols-2">
-        {sorted.map((p) => (
-          <li class="card p-6" data-reveal>
-            <h2 class="text-xl font-semibold">
-              <a href={`/devlog/${p.slug}`} class="hover:underline">{p.title}</a>
-            </h2>
-            <p class="text-sm opacity-80">{fmt(p.date)}</p>
-            <p class="mt-2">{p.summary}</p>
-            <div class="mt-4">
-              <a class="btn btn-primary" href={`/devlog/${p.slug}`}>Read</a>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </section>
-  </div>
+    <ul class="grid gap-6 md:grid-cols-2">
+      {sorted.map((p) => (
+        <li class="card p-6" data-reveal>
+          <h2 class="text-xl font-semibold">
+            <a href={`/devlog/${p.slug}`} class="hover:underline">{p.title}</a>
+          </h2>
+          <p class="text-sm opacity-80">{fmt(p.date)}</p>
+          <p class="mt-2">{p.summary}</p>
+          <div class="mt-4">
+            <a class="btn btn-primary" href={`/devlog/${p.slug}`}>Read</a>
+          </div>
+        </li>
+      ))}
+    </ul>
+  </section>
 </Base>
+

--- a/src/pages/devlog/[slug].astro
+++ b/src/pages/devlog/[slug].astro
@@ -46,9 +46,7 @@ const desc  = meta.summary;
 const dateStr = date ? new Date(date).toLocaleDateString("en-GB", { year:"numeric", month:"long", day:"numeric" }) : "";
 ---
 
-<Base title={title} description={desc}>
-  <div class="vt-backdrop" aria-hidden="true"></div>
-
+<Base title={title} description={desc} pageClass="page-devlog">
   <section class="container mx-auto px-4 py-12">
     <a href="/devlog" class="btn btn-secondary mb-6">← Back to Devlog</a>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -39,8 +39,10 @@ body { color: var(--ink); font-family: theme('fontFamily.body'); }
 
 /* Backdrop is fixed & empty – visuals live on ::before/::after */
 .vt-backdrop{
-  position: fixed; inset: 0; min-height: 100dvh;
-  z-index: 0;                 /* <- background layer (changed from -1) */
+  position: fixed;
+  inset: 0;
+  min-height: 100dvh;
+  z-index: -1;              /* background layer */
   pointer-events: none;
 }
 .vt-backdrop::before{
@@ -66,16 +68,19 @@ body { color: var(--ink); font-family: theme('fontFamily.body'); }
   opacity: var(--noise-opacity, .07);
 }
 
-/* Foreground/content layer — always above backdrop */
+/* Foreground/content layer — always above backdrop and protected from blend */
 .vt-content,
 #content,
-#vt-content {
+#vt-content{
   position: relative;
-  z-index: 1;          /* <- above .vt-backdrop */
-  isolation: isolate;  /* <- prevents blend overlay from washing content */
+  z-index: 1;          /* above .vt-backdrop */
+  isolation: isolate;  /* prevent overlay from washing content */
 }
 
-/* (Optional) On devlog page, disable overlay blending for extra clarity */
+/* Optional: keep nav above content if needed */
+.safenav{ position: relative; z-index: 2; }
+
+/* Optional: on Devlog only, neutralize blend for extra clarity */
 .page-devlog .vt-backdrop::after { mix-blend-mode: normal; }
 
 [data-reveal] {


### PR DESCRIPTION
## Summary
- Correct backdrop layering with z-index fixes and isolation for content
- Consolidate backdrop in Base layout and disable blend on Devlog pages
- Allow Nav to receive class for safe z-index and remove extra backdrops

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab31957bd483289f7f10f99ad09521