### PR TITLE
feat: restyle devlog pages with hell theme

### DIFF
--- a/src/pages/devlog.astro
+++ b/src/pages/devlog.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "../layouts/Base.astro";
 import posts from "../data/devlog.json";
+import "../styles/devlog.css";
 
 const sorted = [...posts].sort((a, b) => new Date(b.date) - new Date(a.date));
 const fmt = (iso) => new Date(iso).toLocaleDateString("en-GB", {
@@ -9,21 +10,19 @@ const fmt = (iso) => new Date(iso).toLocaleDateString("en-GB", {
 ---
 
 <Base title="Devlog" description="Latest updates and progress logs for Voidless Tale." pageClass="page-devlog">
-  <section class="container mx-auto px-4 py-16">
-    <h1 class="font-heading text-3xl md:text-4xl mb-6" data-reveal>Devlog</h1>
-    <p class="opacity-90 mb-8 max-w-2xl" data-reveal>
+  <section class="devlog-container">
+    <h1 class="devlog-heading" data-reveal>Devlog</h1>
+    <p class="devlog-lead" data-reveal>
       Changelogs, experiments, and behind-the-scenes notes.
     </p>
 
-    <ul class="grid gap-6 md:grid-cols-2">
+    <ul class="devlog-list">
       {sorted.map((p) => (
-        <li class="card p-6" data-reveal>
-          <h2 class="text-xl font-semibold">
-            <a href={`/devlog/${p.slug}`} class="hover:underline">{p.title}</a>
-          </h2>
-          <p class="text-sm opacity-80">{fmt(p.date)}</p>
-          <p class="mt-2">{p.summary}</p>
-          <div class="mt-4">
+        <li class="devlog-card" data-reveal>
+          <h2 class="devlog-card-title"><a href={`/devlog/${p.slug}`}>{p.title}</a></h2>
+          <p class="devlog-card-date">{fmt(p.date)}</p>
+          <p class="devlog-card-summary">{p.summary}</p>
+          <div style="margin-top:1rem;">
             <a class="btn btn-primary" href={`/devlog/${p.slug}`}>Read</a>
           </div>
         </li>

--- a/src/pages/devlog/[slug].astro
+++ b/src/pages/devlog/[slug].astro
@@ -2,6 +2,7 @@
 // src/pages/devlog/[slug].astro
 import Base from "../../layouts/Base.astro";
 import list from "../../data/devlog.json";
+import "../../styles/devlog.css";
 
 /** Generate static paths from the union of JSON + optional Markdown posts */
 export function getStaticPaths() {
@@ -47,20 +48,20 @@ const dateStr = date ? new Date(date).toLocaleDateString("en-GB", { year:"numeri
 ---
 
 <Base title={title} description={desc} pageClass="page-devlog">
-  <section class="container mx-auto px-4 py-12">
+  <section class="devlog-container">
     <a href="/devlog" class="btn btn-secondary mb-6">← Back to Devlog</a>
 
-    <h1 class="font-heading text-3xl md:text-4xl" data-reveal>{title}</h1>
-    {dateStr && <p class="opacity-80 text-sm mt-1">{dateStr}</p>}
+    <h1 class="devlog-heading" data-reveal>{title}</h1>
+    {dateStr && <p class="devlog-card-date">{dateStr}</p>}
 
     {Content ? (
-      <article class="mt-6 prose prose-invert max-w-none" data-reveal>
+      <article class="devlog-article" data-reveal>
         <Content />
       </article>
     ) : (
-      <article class="card p-6 mt-6" data-reveal>
-        <p class="opacity-90">{desc}</p>
-        <p class="mt-2 opacity-70 text-sm">Full post coming soon.</p>
+      <article class="devlog-card" data-reveal>
+        <p class="devlog-card-summary">{desc}</p>
+        <p class="devlog-card-date" style="margin-top:0.5rem;">Full post coming soon.</p>
       </article>
     )}
   </section>

--- a/src/styles/devlog.css
+++ b/src/styles/devlog.css
@@ -1,0 +1,83 @@
+/* Custom styles for Devlog pages using Hell theme colors */
+.devlog-container{
+  max-width:80ch;
+  margin:0 auto;
+  padding:4rem 1rem;
+}
+.devlog-heading{
+  font-family:'Cinzel','Uncial Antiqua',serif;
+  font-size:2.25rem;
+  color:var(--accent);
+  margin-bottom:1.5rem;
+}
+.devlog-lead{
+  color:var(--muted);
+  margin-bottom:2rem;
+}
+.devlog-list{
+  display:grid;
+  gap:1.5rem;
+}
+@media(min-width:768px){
+  .devlog-list{ grid-template-columns:repeat(2,1fr); }
+}
+.devlog-card{
+  background:var(--panel);
+  border:1px solid var(--panel-border);
+  border-radius:1rem;
+  padding:1.5rem;
+  box-shadow:0 4px 24px var(--shadow);
+  transition:background .2s,transform .2s;
+}
+.devlog-card:hover{
+  background:color-mix(in srgb,var(--accent) 10%,var(--panel));
+  transform:translateY(-2px);
+}
+.devlog-card-title{
+  font-size:1.25rem;
+  color:var(--ink-strong);
+  margin:0;
+}
+.devlog-card-title a{
+  color:var(--accent);
+  text-decoration:none;
+}
+.devlog-card-title a:hover{ text-decoration:underline; }
+.devlog-card-date{
+  font-size:0.875rem;
+  color:var(--muted);
+  margin-top:0.25rem;
+}
+.devlog-card-summary{
+  margin-top:0.75rem;
+  color:var(--ink);
+}
+
+.devlog-article{
+  background:var(--panel);
+  border:1px solid var(--panel-border);
+  border-radius:1rem;
+  padding:2rem;
+  color:var(--ink-strong);
+  line-height:1.7;
+}
+.devlog-article h1,
+.devlog-article h2,
+.devlog-article h3{
+  color:var(--accent);
+  font-family:'Cinzel','Uncial Antiqua',serif;
+  margin-top:1.5rem;
+}
+.devlog-article p{ margin-top:1rem; }
+.devlog-article a{ color:var(--accent-2); text-decoration:underline; }
+.devlog-article code{
+  background:var(--bg-2);
+  padding:0.2rem 0.4rem;
+  border-radius:4px;
+}
+.devlog-article pre{
+  background:var(--bg-2);
+  padding:1rem;
+  border-radius:0.5rem;
+  overflow-x:auto;
+}


### PR DESCRIPTION
## Summary
- add custom Hell-themed stylesheet for devlog pages
- rebuild devlog index using new styles
- apply same styling to individual devlog posts while preserving JSON+MD loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3c1895108328bfdaa7b71e3d15b0