### PR TITLE
Fix navigation to wiki and smith pages

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -5,9 +5,9 @@ const { class: className = "" } = Astro.props;
   <div class="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
     <a href="/" class="font-heading text-lg">Voidless Tale</a>
     <ul class="flex items-center gap-4 text-sm">
-      <li><a href="/wiki" class="hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Wiki</a></li>
-      <li><a href="/devlog" class="hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Devlog</a></li>
-      <li><a href="/smith" class="hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Voidless Smith</a></li>
+      <li><a href="/wiki/" class="hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Wiki</a></li>
+      <li><a href="/devlog/" class="hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Devlog</a></li>
+      <li><a href="/smith/" class="hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent">Voidless Smith</a></li>
       <!-- Theme switch on the right -->
       <li class="ml-auto flex items-center">
       <button


### PR DESCRIPTION
## Summary
- fix header links by adding trailing slashes for wiki, devlog and smith pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab410e17c88328aec8776ebf07b12f