### PR TITLE
Add Website & Visual Overhaul devlog entry

### DIFF
--- a/src/content/devlog/website-overhaul.md
+++ b/src/content/devlog/website-overhaul.md
@@ -7,10 +7,10 @@ We’ve rolled out a **major update** to the Voidless Tale website and brand. 
 - **Dark gradient look & feel** – The entire site now uses a dark‑gray and purple gradient canvas with subtle noise. Panels, buttons and typography have been polished for a slick, cohesive feel.
 - **Hero billboards** – Home and Game pages now open with big hero sections that tell the game’s story and guide players toward the Voidless Tale game and the Voidless Smith tool.
 - **Store CTAs** – Added a “Where to play” bar with placeholder Steam and itch.io buttons, plus a sticky wishlist bar for mobile.
-- **Press ribbon & gallery** – Added a badge ribbon highlighting Solo Dev, Pixel Art, Mod Support and Action RPG pillars, and a scroll‑snap gallery row for screenshots.
+- **Press ribbon & gallery** – Added a badge ribbon highlighting Solo Dev, Pixel Art, Mod Support and Action RPG pillars, and a scroll‑snap gallery row for screenshots.
 - **New Devlog structure** – Devlog entries are now Markdown files in `/src/content/devlog`—the new structure powers the `/devlog` page. Existing posts like “Core Mechanics” and “First Steps” were ported to this format.
-- **Wiki** – Added a Wiki section with pages for Story, Domains & Bosses, Progression & Systems, Modding & Voidless Smith, Roadmap, Presskit, FAQ and Licensing, all summarised from the GDD.
-- **Split licensing** – The website code is MIT‑licensed, while story, characters, names, art, audio and the Voidless Smith branding remain proprietary. See `LICENSE`, `ASSETS_LICENSE.md`, `TOOLS_LICENSE.md` and `TRADEMARKS.md` for details.
+- **Wiki** – Added a dedicated Wiki with pages for Story, Domains & Bosses, Progression & Systems, Modding & Voidless Smith, Roadmap, Presskit, FAQ and Licensing, all summarised from the GDD.
+- **Split licensing** – The website code is MIT‑licensed, while story, characters, names, art, audio and the Voidless Smith branding remain proprietary. See `LICENSE`, `ASSETS_LICENSE.md`, `TOOLS_LICENSE.md` and `TRADEMARKS.md` for details.
 - **Bug fixes & UX improvements** – Fixed navigation links by removing a broken `<base>` tag, enforced trailing slashes for GitHub Pages, added a friendly 404 page and ensured the gradient background fills the viewport on all devices. A “safe‑area” padding now prevents notches on mobile, and global margins have been reset to eliminate unexpected gaps.
 
 Thanks for following along—stay tuned for more devlog updates as the game and tools evolve!

--- a/src/data/devlog.json
+++ b/src/data/devlog.json
@@ -5,10 +5,16 @@
     "slug": "first-steps",
     "summary": "Basic level build"
   },
-  {
-    "title": "Core Mechanics",
-    "date": "2025-09-22",
-    "slug": "core-mechanics",
-    "summary": "Added few core mechanics"
-  }
+      {
+        "title": "Core Mechanics",
+        "date": "2025-09-22",
+        "slug": "core-mechanics",
+        "summary": "Added few core mechanics"
+      },
+      {
+        "title": "Website & Visual Overhaul",
+        "date": "2025-09-29",
+        "slug": "website-overhaul",
+        "summary": "Site overhaul with dark gradient, hero billboards, wiki and licensing updates"
+      }
 ]


### PR DESCRIPTION
## Summary
- add a "Website & Visual Overhaul" devlog entry covering the latest site and branding updates
- register the new post in `src/data/devlog.json` so it appears on the devlog index

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da6b45b6948328ac002f8b8908d3f1