### PR TITLE
Add Decap CMS admin panel for devlog

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,23 @@
+backend:
+  name: github
+  repo: Jurislav/voidlesstale.github.io
+  branch: main
+
+media_folder: public/uploads
+public_folder: /uploads
+
+collections:
+  - name: devlog
+    label: Devlog
+    folder: src/content/devlog
+    create: true
+    slug: "{{slug}}"
+    extension: md
+    format: frontmatter
+    fields:
+      - { name: title, label: Title, widget: string }
+      - { name: description, label: Description, widget: text }
+      - { name: pubDate, label: Publication Date, widget: datetime }
+      - { name: heroImage, label: Hero Image, widget: image, required: false }
+      - { name: draft, label: Draft, widget: boolean, default: false }
+      - { name: body, label: Body, widget: markdown }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Content Manager</title>
+  </head>
+  <body>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide an in-repo CMS admin UI at `/admin` so devlog posts in `src/content/devlog` can be created and edited via Decap CMS without changing existing Astro routes.

### Description
- Added `public/admin/index.html` which loads Decap CMS from the CDN to expose the admin interface at `/admin`.
- Added `public/admin/config.yml` with a GitHub backend configured for `repo: Jurislav/voidlesstale.github.io` on branch `main`, `media_folder: public/uploads`, and `public_folder: /uploads`.
- Configured a `devlog` collection targeting `src/content/devlog` with `create: true`, `slug: "{{slug}}"`, `extension: md`, `format: frontmatter`, and fields `title`, `description`, `pubDate`, `heroImage` (optional), `draft` (default false), and `body`.
- Files changed: `public/admin/index.html` and `public/admin/config.yml`.

### Testing
- Repository status was checked after changes and reported the new files as present.
- Changes were recorded to version control successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a3fcadf0832887ed211833820402)