### PR TITLE
Serve Decap CMS at /admin via Astro route

### DIFF
--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -1,9 +1,9 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Content Manager</title>
+    <title>Voidless Tale Admin</title>
   </head>
   <body>
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>


### PR DESCRIPTION
### Motivation
- The site previously served a static `public/admin/index.html` which caused `/admin` to be downloaded instead of rendered as a normal HTML page.
- `/admin` should be a proper Astro route so the Decap CMS UI opens in the browser while keeping `public/admin/config.yml` available at `/admin/config.yml`.

### Description
- Removed the static `public/admin/index.html` and replaced it with a real Astro route at `src/pages/admin.astro`.
- `src/pages/admin.astro` renders `<!doctype html>` with `html lang="en"`, the required meta tags, the title `Voidless Tale Admin`, and loads Decap CMS via the CDN script `https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js`.
- Left `public/admin/config.yml` unchanged so the configuration remains available at `/admin/config.yml`.

### Testing
- Verified file presence with `test -f public/admin/index.html`, `test -f public/admin/config.yml`, and `test -f src/pages/admin.astro`, and the checks reported the expected results.
- Inspected `src/pages/admin.astro` with `nl -ba src/pages/admin.astro` to confirm the required document structure and script tag were present.
- Listed `public/admin` with `ls public/admin` to confirm `config.yml` remains in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a6eb498c83288acee19984be2a33)