### PR TITLE
Set up Decap CMS at /cms and redirect /admin

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Voidless Tale Admin</title>
+    <meta http-equiv="refresh" content="0; url=/cms/" />
+    <title>Redirecting to CMS</title>
   </head>
   <body>
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <p>Redirecting to <a href="/cms/">Voidless Tale CMS</a>...</p>
   </body>
 </html>

--- a/public/cms/config.yml
+++ b/public/cms/config.yml
@@ -1,0 +1,23 @@
+backend:
+  name: github
+  repo: Jurislav/voidlesstale.github.io
+  branch: main
+
+media_folder: public/uploads
+public_folder: /uploads
+
+collections:
+  - name: devlog
+    label: Devlog
+    folder: src/content/devlog
+    create: true
+    slug: "{{slug}}"
+    extension: md
+    format: frontmatter
+    fields:
+      - { label: Title, name: title, widget: string }
+      - { label: Description, name: description, widget: text }
+      - { label: Publish Date, name: pubDate, widget: datetime }
+      - { label: Hero Image, name: heroImage, widget: image, required: false }
+      - { label: Draft, name: draft, widget: boolean, default: false }
+      - { label: Body, name: body, widget: markdown }

--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voidless Tale CMS</title>
+  </head>
+  <body>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Cloudflare was causing `/admin` to download an `admin.txt` file, preventing the Decap CMS browser UI from loading. 
- The site needs an alternate, reliable entrypoint for the Decap CMS UI that avoids `/admin`. 
- Provide a simple redirect from `/admin/` to the new `/cms/` entrypoint while keeping the CMS config accessible as YAML.

### Description
- Added a Decap CMS entry page at `public/cms/index.html` that loads `decap-cms@^3.0.0` with the exact HTML requested. 
- Added Decap CMS configuration at `public/cms/config.yml` with a GitHub backend pointing to the `Jurislav/voidlesstale.github.io` repo on branch `main` and a `devlog` collection. 
- Replaced the existing `/admin` page content with a redirect page at `public/admin/index.html` that meta-refreshes to `/cms/` and provides a link fallback. 
- Ensured `public/uploads/.gitkeep` already existed and verified no target admin pages (`src/pages/admin.astro`, `src/pages/admin/index.astro`, `admin.txt`, `document.txt`) were present to delete.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Verified the new files exist with `git status --short` and inspected `public/cms/index.html`, `public/cms/config.yml`, and `public/admin/index.html`. 
- Confirmed there was an existing `public/uploads/.gitkeep` with `test -f public/uploads/.gitkeep; echo $?`. 
- Searched for leftover admin/doc files with `rg --files public src | rg 'admin|cms|admin.txt|document.txt'` and found only the intended files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b1faf3688328b48b9ce7e5ad2356)